### PR TITLE
Expose 1433 port via docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=1Secure*Password1
+    ports:
+      - 1433:1433
 
   dockersqlserver:
     image: ${DOCKER_REGISTRY-}dockersqlserver


### PR DESCRIPTION
Read your really helpful post on https://samwalpole.com/how-to-run-aspnet-core-and-sql-server-from-docker
and hit a problem that if i wanted to connect to the db via Rider or DataGrip, then the TCP port was blocked. Having added port mapping, got a successful connection. Feel free to refuse the PR if it feels unnecessary for your demo